### PR TITLE
support wayland

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(RTAUDIO_VERSION 6.0.1)
 option(GLFW_BUILD_DOCS ON)
 option(GLFW_BUILD_EXAMPLES OFF)
 option(GLFW_BUILD_TESTS ON)
+option(GLFW_USE_WAYLAND OFF)
 
 # RtAudio configuration options
 set(RTAUDIO_BUILD_TESTING OFF CACHE BOOL "Build RtAudio tests" FORCE)
@@ -120,3 +121,12 @@ target_link_libraries(${PROJECT_NAME}
     rtaudio
     ${GLAD_LIBRARIES}
 )
+
+if (GLFW_USE_WAYLAND)
+    find_package(OpenGL REQUIRED COMPONENTS EGL)
+    target_link_libraries(${PROJECT_NAME}
+        xkbcommon
+        OpenGL::EGL
+        )
+endif ()
+


### PR DESCRIPTION
# DONE
- improved Wayland compatibility (didn't build otherwise)
- added cmake option flag for us Wayland-andies

# ETC

Stuff that might be useful.

## NixOS

Since I'm a NixOS user (btw) I had to add some packages to my devShell: https://github.com/UsatiyNyan/flake.nix/blob/main/dev-shells/wayland_cpp.nix

shell.nix for your repo would look like this:
```nix
{pkgs ? import <nixpkgs> {}}:
pkgs.mkShell {
  buildInputs = with pkgs; [
    extra-cmake-modules

    wayland
    wayland-scanner
    wayland-protocols
    libxkbcommon
    libffi

    libglvnd
  ];
}
```

There are also audio capture issues since I'm using pipewire... but that's not as important.