### PR TITLE
Dev/sound debug view

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -109,6 +109,11 @@ void Engine::update() {
 		this->influences[1] -= this->mouse->deltaX;
 	}
 
+    // sound processing
+    if (auto* soundBufferList = sound.extractDataBufferList()) {
+        soundBufferList->destroy();
+    }
+
 	ImGui_ImplOpenGL3_NewFrame();
 	ImGui_ImplGlfw_NewFrame();
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -109,8 +109,16 @@ void Engine::update() {
 		this->influences[1] -= this->mouse->deltaX;
 	}
 
+    // data model for sound visualization
+    std::vector<float> currentSoundBuffer;
+
     // sound processing
     if (auto* soundBufferList = sound.extractDataBufferList()) {
+        // would process only "head" of the stack, since it is the most relevant
+        // other sound frames could be processed too
+        // since we are moving, no extra allocations would occur
+        currentSoundBuffer = std::move(soundBufferList->payload);
+
         soundBufferList->destroy();
     }
 
@@ -139,6 +147,20 @@ void Engine::update() {
 	if (ImGui::Button("SAVE")) {
 		this->save();
 	}
+
+    ImGui::Checkbox("AUDIO DEBUG VIEW", &audioDebugComponent.isShown);
+    if (audioDebugComponent.isShown) {
+        ImGui::PlotLines(
+            "waveform",
+            currentSoundBuffer.data(),
+            static_cast<int>(currentSoundBuffer.size()),
+            0,
+            nullptr,
+            0, audioDebugComponent.scale,
+            ImVec2(0, 100)
+        );
+        ImGui::SliderFloat("scale", &audioDebugComponent.scale, 0.0f, 1.0f);
+    }
 
 	ImGui::Spacing();
 	ImGui::PopStyleColor();

--- a/src/engine.hpp
+++ b/src/engine.hpp
@@ -65,6 +65,11 @@ class Engine {
 	vec4 influences = vec4(0.0, 0.0, 0.0, 0.0);
 	bool pulseUp = true;
 
+    struct AudioDebugComponent {
+        float scale = 1.0f;
+        bool isShown = false;
+    } audioDebugComponent;
+
 	bool shouldClose();
 };
 

--- a/src/util/sound.hpp
+++ b/src/util/sound.hpp
@@ -8,6 +8,15 @@
 #include <vector>
 
 class Sound {
+public:
+    // simple intrusive forward list, used as a stack
+    struct DataBufferNode {
+        DataBufferNode* next = nullptr;
+        std::vector<float> payload;
+        
+        void destroy();
+    };
+
   public:
 	Sound();
 	~Sound();
@@ -15,12 +24,11 @@ class Sound {
 	bool start();			// start capturing
 	void stop();			// stop capturing
 	float getLevel() const; // thread-safe dB read
+    
+    // don't forget to call DataBufferNode::destroy() after processing
+    DataBufferNode* extractDataBufferList();
 
   private:
-	RtAudio adc;
-	std::atomic<float> current_dB{0.0f};
-	bool running = false;
-
 	static int static_callback(void *outputBuffer, void *inputBuffer,
 							   unsigned int nBufferFrames, double streamTime,
 							   RtAudioStreamStatus status, void *userData);
@@ -28,6 +36,12 @@ class Sound {
 	int callback(void *outputBuffer, void *inputBuffer,
 				 unsigned int nBufferFrames, double streamTime,
 				 RtAudioStreamStatus status);
+
+  private:
+	RtAudio adc;
+    std::atomic<DataBufferNode*> dataBufferList{nullptr};
+	std::atomic<float> current_dB{0.0f};
+	bool running = false;
 };
 
 #endif // SOUND_H


### PR DESCRIPTION
I wanted a debug view for sound, whilst I was fixing my audio issues. So I made this:

# DONE

- brought audio buffer to the main thread
- debug view for audio

<img width="1917" height="1157" alt="image" src="https://github.com/user-attachments/assets/2fbd4f82-db98-4494-9068-1b5aa792b4fa" />

## notes on impl

I chose lock-free stack, since it wouldn't incur blocking operations between audio and graphics threads. And a basic allocator should easily handle it's own ringbuffer of memory in the audio thread (mimalloc or similar should handle it easily). 
Another completely valid solution would be to use 1 vector and lock a mutex around it, but it's not as fool proof (deadlocks), and might cause hiccups in graphics thread.
The bestest solution would have been to use lock-free spsc queue like that: 
- https://github.com/UsatiyNyan/serious-music-visualizer/blob/main/include/sa/audio_data.hpp#L36
- https://github.com/UsatiyNyan/serious-music-visualizer/blob/main/src/sa/audio_data.cpp#L13C1-L21C2

I used this impl, pretty much industry standard: https://github.com/rigtorp/SPSCQueue

# P.S.
- Please add clang-format.yaml to the repo! These tab/spaces diffs ICANT.
- as mentioned above, I actually used to work with audio too, and used miniaudio library for that, very convenient library (no icky exceptions bueeehh):
  - https://github.com/mackron/miniaudio
  - https://github.com/UsatiyNyan/serious-music-visualizer/blob/main/dependencies/miniaudio/CMakeLists.txt - example usage